### PR TITLE
[#157470367] Improve GitHub retrieve performance

### DIFF
--- a/cmd/all.go
+++ b/cmd/all.go
@@ -33,7 +33,7 @@ Beware! May take days to complete.`,
 		}
 
 		// Initiate a channel of repositories.
-		repositories := make(chan crawler.Repository, 100)
+		repositories := make(chan crawler.Repository, 1000)
 
 		// Process each domain service.
 		for _, domain := range domains {

--- a/cmd/single.go
+++ b/cmd/single.go
@@ -36,7 +36,7 @@ Beware! May take days to complete.`,
 		}
 
 		// Initiate a channel of repositories.
-		repositories := make(chan crawler.Repository, 100)
+		repositories := make(chan crawler.Repository, 1000)
 
 		// Process each domain service.
 		for _, domain := range domains {

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -93,11 +93,13 @@ func checkAvailability(repository Repository, processedCounter prometheus.Counte
 		saveFile(domain, name, resp.Body)
 
 		// Validate file.
-		err := validateRemoteFile(resp.Body, fileRawUrl)
-		if err != nil {
-			log.Warn("Validator fails for: " + fileRawUrl)
-			log.Warn("Validator errors:" + err.Error())
-		}
+		// TODO: uncomment these lines when needs to validate publiccode.yml
+		// TODO: now validation is ulesess because we test on .gitignore file.
+		// err := validateRemoteFile(resp.Body, fileRawUrl)
+		// if err != nil {
+		// 	log.Warn("Validator fails for: " + fileRawUrl)
+		// 	log.Warn("Validator errors:" + err.Error())
+		// }
 	}
 }
 

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/italia/developers-italia-backend/httpclient"
 	"github.com/italia/developers-italia-backend/metrics"
@@ -50,8 +49,6 @@ func ProcessDomain(domain Domain, repositories chan Repository) {
 			log.Errorf("error reading %s repository list: %v. NextUrl: %v", url, err, nextURL)
 			log.Errorf("Retry: %s", nextURL)
 			nextURL = url
-			//close(repositories): ok if only one repo. If more parallel it generates panics.
-			//return
 		}
 		// If reached, the repository list was successfully retrieved.
 		// Delete the repository url from redis.
@@ -76,14 +73,7 @@ func ProcessRepositories(repositories chan Repository) {
 	// Init Prometheus for metrics.
 	processedCounter := metrics.PrometheusCounter("repository_processed", "Number of repository processed.")
 
-	// Throttle requests.
-	// Time limits should be calibrated on more tests in order to avoid errors and bans.
-	throttleRate := time.Second / 1000
-	throttle := time.Tick(throttleRate)
-
 	for repository := range repositories {
-		// Throttle down the calls.
-		<-throttle
 		go checkAvailability(repository, processedCounter)
 	}
 }

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -112,7 +112,7 @@ func GetURL(URL string, headers map[string]string) (HttpResponse, error) {
 
 			if retryAfter := resp.Header.Get(headerRetryAfter); retryAfter != "" {
 				// If Retry-after is set, use that value.
-				log.Infof("Waiting: %s seconds. (The value of %s)", retryAfter, headerRetryAfter)
+				log.Infof("Waiting: %s seconds for %s. (The value of %s)", retryAfter, URL, headerRetryAfter)
 				secondsAfterRetry, _ := strconv.Atoi(retryAfter)
 				time.Sleep(time.Second * time.Duration(secondsAfterRetry))
 			} else {
@@ -121,7 +121,7 @@ func GetURL(URL string, headers map[string]string) (HttpResponse, error) {
 				// Perform a backoff sleep time.
 				sleep = time.Duration(expBackoffWait) * time.Second
 				expBackoffAttemps = expBackoffAttemps + 1
-				log.Info("Rate limit reached, sleep %v minutes\n", sleep)
+				log.Info("Rate limit reached, sleep %v \n", sleep)
 				time.Sleep(sleep)
 			}
 
@@ -130,7 +130,7 @@ func GetURL(URL string, headers map[string]string) (HttpResponse, error) {
 
 			if retryAfter := resp.Header.Get(headerRetryAfter); retryAfter != "" {
 				// If Retry-after is set, use that value.
-				log.Infof("Waiting: %s seconds. (The value of %s)", retryAfter, headerRetryAfter)
+				log.Infof("Waiting: %s seconds for %s. (The value of %s)", retryAfter, URL, headerRetryAfter)
 				secondsAfterRetry, _ := strconv.Atoi(retryAfter)
 				time.Sleep(time.Second * time.Duration(secondsAfterRetry))
 
@@ -159,7 +159,7 @@ func GetURL(URL string, headers map[string]string) (HttpResponse, error) {
 				// Perform a backoff sleep time.
 				sleep = time.Duration(expBackoffWait) * time.Second
 				expBackoffAttemps = expBackoffAttemps + 1
-				log.Infof("Forbidden access to %s : sleep %v minutes\n", URL, sleep)
+				log.Infof("Forbidden access to %s : sleep %v \n", URL, sleep)
 				time.Sleep(sleep)
 			}
 
@@ -170,7 +170,7 @@ func GetURL(URL string, headers map[string]string) (HttpResponse, error) {
 			// Perform a backoff sleep time.
 			sleep = time.Duration(expBackoffWait) * time.Second
 			expBackoffAttemps = expBackoffAttemps + 1
-			log.Infof("Invalid status code on %s : sleep %v minutes\n", URL, sleep)
+			log.Infof("Invalid status code on %s : sleep %v \n", URL, sleep)
 			time.Sleep(sleep)
 		}
 	}


### PR DESCRIPTION
Add goroutines for single repository retrieved from all repository list APIs (it is necessary in order to obtain the "main branch" property).