### PR TITLE
[#159065604] Update activity ranges.

### DIFF
--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -27,7 +27,7 @@ var crawlCmd = &cobra.Command{
 		// Update ipa to lastest data.
 		err := ipa.UpdateFile("./ipa/amministrazioni.txt", "http://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt")
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
 		}
 		// Index for actual process.
 		index := strconv.FormatInt(time.Now().Unix(), 10)

--- a/cmd/one.go
+++ b/cmd/one.go
@@ -27,7 +27,7 @@ No organizations! Only single repositories!`,
 		// Update ipa to lastest data.
 		err := ipa.UpdateFile("./ipa/amministrazioni.txt", "http://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt")
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
 		}
 
 		// Read repository URL.

--- a/ipa/amministrazioni.go
+++ b/ipa/amministrazioni.go
@@ -2,7 +2,6 @@ package ipa
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -53,6 +52,7 @@ type Amministrazione struct {
 func UpdateFile(fileName, fileURL string) error {
 	info, err := os.Stat(fileName)
 	if err != nil {
+		log.Fatal(err)
 		return err
 	}
 	today := time.Now()
@@ -62,10 +62,11 @@ func UpdateFile(fileName, fileURL string) error {
 
 	// If amministrazioni.txt is older that 2 days.
 	if downloadTime.Before(older) {
-		fmt.Println("download a new amministrazioni.txt ...")
+		log.Info("download a new amministrazioni.txt ...")
 
 		err := downloadFile(fileName, fileURL)
 		if err != nil {
+			log.Error(err)
 			return err
 		}
 	}
@@ -140,7 +141,7 @@ func manageLine(line string) Amministrazione {
 
 func downloadFile(filepath string, url string) error {
 
-	// Create the file
+	// Create the file.
 	out, err := os.Create(filepath)
 	if err != nil {
 		return err

--- a/vitality-ranges.yml
+++ b/vitality-ranges.yml
@@ -2,55 +2,91 @@
   ranges:
     - min: 0
       max: 2
-      points: 1
+      points: 4
     - min: 2
       max: 4
-      points: 5
+      points: 8
     - min: 4
-      max: 6
-      points: 10
-    - min: 6
-      max: 10
-      points: 15
-    - min: 10
-      max: 10000
+      max: 8
+      points: 12
+    - min: 8
+      max: 12
+      points: 16
+    - min: 12
+      max: 16
       points: 20
+    - min: 16
+      max: 20
+      points: 24
+    - min: 20
+      max: 24
+      points: 28
+    - min: 24
+      max: 28
+      points: 24
+    - min: 28
+      max: 10000
+      points: 36
 
 - name: codeActivity #number of commits and merges per day
   ranges:
     - min: 0
       max: 2
-      points: 1
+      points: 4
     - min: 2
-      max: 5
-      points: 5
-    - min: 5
-      max: 10
-      points: 15
-    - min: 10
+      max: 4
+      points: 6
+    - min: 4
+      max: 6
+      points: 8
+    - min: 6
+      max: 9
+      points: 14
+    - min: 9
+      max: 12
+      points: 20
+    - min: 12
+      max: 15
+      points: 26
+    - min: 15
+      max: 18
+      points: 32
+    - min: 18
+      max: 25
+      points: 38
+    - min: 25
+      max: 30
+      points: 44
+    - min: 30
+      max: 35
+      points: 50
+    - min: 35
       max: 10000
-      points: 25
+      points: 60
 
 - name: releaseHistory #number of releases per day
   ranges:
     - min: 0
       max: 1
-      points: 1
-    - min: 1
-      max: 5
-      points: 10
-    - min: 5
-      max: 100
       points: 20
+    - min: 1
+      max: 2
+      points: 30
+    - min: 2
+      max: 4
+      points: 40
+    - min: 4
+      max: 100
+      points: 50
 
 - name: longevity #repository age in days
   ranges:
     - min: 0
       max: 365
-      points: 10
+      points: 20
     - min: 365
       max: 730
-      points: 15
+      points: 30
     - min: 730
       max: 10000
-      points: 20
+      points: 35

--- a/vitality-ranges.yml
+++ b/vitality-ranges.yml
@@ -23,7 +23,7 @@
       points: 28
     - min: 24
       max: 28
-      points: 24
+      points: 32
     - min: 28
       max: 10000
       points: 36
@@ -31,11 +31,8 @@
 - name: codeActivity #number of commits and merges per day
   ranges:
     - min: 0
-      max: 2
-      points: 4
-    - min: 2
       max: 4
-      points: 6
+      points: 2
     - min: 4
       max: 6
       points: 8


### PR DESCRIPTION
Activity ranges (calculated daily):

- usercommunity (before that day): 0-28 authors in values are 4-36 points. Max 36 points.
- codeActivity per day (commits+merges): 0-35 in value are 2-60 points. Max 60 points.
- releaseHistory per day (tags per day): points are: number of tags + 20. Max 50 points.
- longevity (repository age): <1y value 20 points, 1y<age<2y value 30 points, more 35 points