### PR TITLE
Switch to BCP 47 language codes

### DIFF
--- a/crawler/go.mod
+++ b/crawler/go.mod
@@ -1,13 +1,14 @@
 module github.com/italia/developers-italia-backend/crawler
 
 require (
+	github.com/Jeffail/gabs v1.2.0 // indirect
 	github.com/alecthomas/gometalinter v3.0.0+incompatible // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/dyatlov/go-oembed v0.0.0-20180429203341-4bc5ab7a42e9
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/icza/dyno v0.0.0-20180601094105-0c96289f9585
-	github.com/italia/publiccode-parser-go v0.0.0-20190211210212-681bbad861e9
+	github.com/italia/publiccode-parser-go v0.0.0-20190228115450-b3e7c1946c52
 	github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/nicksnyder/go-i18n v1.10.0 // indirect

--- a/crawler/go.sum
+++ b/crawler/go.sum
@@ -1,5 +1,7 @@
 github.com/Jeffail/gabs v1.1.1 h1:V0uzR08Hj22EX8+8QMhyI9sX2hwRu+/RJhJUmnwda/E=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
+github.com/Jeffail/gabs v1.2.0 h1:uFhoIVTtsX7hV2RxNgWad8gMU+8OJdzFbOathJdhD3o=
+github.com/Jeffail/gabs v1.2.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/gometalinter v3.0.0+incompatible h1:+A0g3WZuqrIRQtFITjs53Dxu7S8yj99GY3u53Szo5p0=
 github.com/alecthomas/gometalinter v3.0.0+incompatible/go.mod h1:qfIpQGGz3d+NmgyPBqv+LSh50emm1pt72EtcX2vKYQk=
@@ -56,6 +58,8 @@ github.com/italia/publiccode-parser-go v0.0.0-20190211200555-25e5a4737bf9 h1:L3R
 github.com/italia/publiccode-parser-go v0.0.0-20190211200555-25e5a4737bf9/go.mod h1:u6MAHxWmyvVRhZZDPOtEVHaXD5Rnm6K3IjwlQKcjWjM=
 github.com/italia/publiccode-parser-go v0.0.0-20190211210212-681bbad861e9 h1:sZfKnHdpdZWJY/rMiGah1KbIGGRhNxfIdDZcv6WOOY0=
 github.com/italia/publiccode-parser-go v0.0.0-20190211210212-681bbad861e9/go.mod h1:u6MAHxWmyvVRhZZDPOtEVHaXD5Rnm6K3IjwlQKcjWjM=
+github.com/italia/publiccode-parser-go v0.0.0-20190228115450-b3e7c1946c52 h1:Qx9wflKor75GDiM6/MVwjmHqErWSnPK+VcuS/GAubOE=
+github.com/italia/publiccode-parser-go v0.0.0-20190228115450-b3e7c1946c52/go.mod h1:OoiHTIcVrQlgywqzjwAniJWC4a9kQ6JJIA3kEEa7nnw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/crawler/jekyll/softwares.go
+++ b/crawler/jekyll/softwares.go
@@ -149,9 +149,9 @@ func (sw *software) findVariants(elasticClient *es.Client) []software {
 
 // variantsFeatures returns features of variants that are not included in this one
 func (sw *software) variantsFeatures() map[string][]string {
-	diff := map[string][]string{}  // "ita" => [ feature, feature ... ]
+	diff := map[string][]string{}  // "it" => [ feature, feature ... ]
 
-	for _, lang := range []string{"eng", "ita"} {
+	for _, lang := range []string{"en", "it"} {
 		for _, variant := range sw.variants {
 			for _, oldFeature := range variant.PublicCode.Description[lang].Features {
 				if !funk.Contains(sw.PublicCode.Description[lang].Features, oldFeature) {

--- a/docs/mappingElasticsearch.md
+++ b/docs/mappingElasticsearch.md
@@ -347,7 +347,7 @@ There are two main indices:
             "type": "text",
             "index": false
           },
-          "eng": {
+          "en": {
             "properties": {
               "localised-name": {
                 "type": "text",
@@ -359,7 +359,7 @@ There are two main indices:
               }
             }
           },
-          "ita": {
+          "it": {
             "properties": {
               "localised-name": {
                 "type": "text",
@@ -388,7 +388,7 @@ There are two main indices:
             "type": "text",
             "index": false
           },
-          "eng": {
+          "en": {
             "properties": {
               "localised-name": {
                 "type": "text",
@@ -412,7 +412,7 @@ There are two main indices:
               }
             }
           },
-          "ita": {
+          "it": {
             "properties": {
               "localised-name": {
                 "type": "text",
@@ -440,11 +440,11 @@ There are two main indices:
       },
       "old-feature-list": {
         "properties": {
-          "ita": {
+          "it": {
             "type": "keyword",
             "index": false
           },
-          "eng": {
+          "en": {
             "type": "keyword",
             "index": false
           }


### PR DESCRIPTION
As of now this crawler expects three-letter language codes as sub-keys of `description/`, according to [publiccode.yml 0.1](https://github.com/italia/publiccode.yml/tree/0.1).

We're switching to BCP 47 in 0.2. The Go parser was already updated so that it accepts two or thee letter codes (plus all the BCP 47 set) and always returns the canonicalized BCP 47 form.

This is a **breaking change**: we need to update all the current entries in Elasticsearch and make sure the new mapping is applied.