### PR TITLE
Improvements to the IndicePA import

### DIFF
--- a/crawler/config.toml.example
+++ b/crawler/config.toml.example
@@ -22,6 +22,7 @@ ELASTIC_INDICEPA_INDEX   = "indicepa"
 # URL of the list of Italian public administration agencies
 INDICEPA_URL = "https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt"
 INDICEPA_AOO_URL = "https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=aoo.txt"
+INDICEPA_OU_URL = "https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=ou.txt"
 
 # Directory for storing working files
 CRAWLER_DATADIR = "/data/crawler"

--- a/crawler/elastic/elastic.go
+++ b/crawler/elastic/elastic.go
@@ -509,6 +509,9 @@ const (
             "analyzer": "autocomplete",
             "search_analyzer": "autocomplete_search"
           },
+          "type": {
+            "type": "keyword"
+          },
           "pec": {
             "type": "keyword"
           },

--- a/crawler/ipa/amministrazioni.go
+++ b/crawler/ipa/amministrazioni.go
@@ -112,6 +112,7 @@ func saveIPAToElasticsearch(elasticClient *es.Client) error {
 	type amministrazioneES struct {
 		IPA         string     `json:"ipa"`
 		Description string     `json:"description"`
+		Type        string     `json:"type"`
 		PEC         string     `json:"pec"`
 		Offices     []officeES `json:"office"`
 	}
@@ -140,6 +141,7 @@ func saveIPAToElasticsearch(elasticClient *es.Client) error {
 		amm := amministrazioneES{
 			IPA:         ipaCode,
 			Description: line[1],
+			Type:        line[12],
 		}
 		if line[17] == "pec" {
 			amm.PEC = line[16]


### PR DESCRIPTION
This PR improves the IndicePA data in two ways:

* it imports the 105k+ OU records from IndicePA in addition to the AOOs that we already have, thus making our index more complete;
* it imports the "Tipologia" (Type) field too, so that we can filter by entity type.