### PR TITLE
Fix developers.italia.it#473 dots in slugs are replaced by an underscore

### DIFF
--- a/crawler/crawler/saveToElasticsearch.go
+++ b/crawler/crawler/saveToElasticsearch.go
@@ -112,6 +112,7 @@ func (repo *Repository) generateID() string {
 // generateSlug generates a readable unique string based on repository name.
 func (repo *Repository) generateSlug() string {
 	vendorAndName := strings.Replace(repo.Name, "/", "-", -1)
+	vendorAndName = strings.ReplaceAll(vendorAndName, ".", "_")
 
 	if repo.Pa.CodiceIPA == "" {
 		ID := repo.generateID()


### PR DESCRIPTION
This will fixes https://github.com/italia/developers.italia.it/issues/473 all dots in slugs will be replaced by `_`. Jekyll misunderstand dots and tends to interpretate them as subfolders.