### PR TITLE
Fixes #112 exiting from repos loop whether api returns error

### DIFF
--- a/crawler/crawler/github.go
+++ b/crawler/crawler/github.go
@@ -271,10 +271,11 @@ func RegisterGithubAPI() OrganizationHandler {
 			// Get List of files.
 			resp, err := httpclient.GetURL(contents, headers)
 			if err != nil {
-				return link, err
+				log.Errorf("Request returned an error: %v", err)
+				continue
 			}
 			if resp.Status.Code != http.StatusOK {
-				log.Infof("Request returned an invalid status code: %s", string(resp.Body))
+				log.Infof("Request returned an invalid status code: %s", resp.Status.Code)
 			}
 			// Fill response as list of values (repositories data).
 			var files GithubFiles

--- a/crawler/crawler/github.go
+++ b/crawler/crawler/github.go
@@ -275,7 +275,7 @@ func RegisterGithubAPI() OrganizationHandler {
 				continue
 			}
 			if resp.Status.Code != http.StatusOK {
-				log.Infof("Request returned an invalid status code: %s", resp.Status.Code)
+				log.Infof("Request returned an invalid status code: %d", resp.Status.Code)
 			}
 			// Fill response as list of values (repositories data).
 			var files GithubFiles

--- a/crawler/crawler/saveToElasticsearch.go
+++ b/crawler/crawler/saveToElasticsearch.go
@@ -112,6 +112,7 @@ func (repo *Repository) generateID() string {
 // generateSlug generates a readable unique string based on repository name.
 func (repo *Repository) generateSlug() string {
 	vendorAndName := strings.Replace(repo.Name, "/", "-", -1)
+	vendorAndName = strings.ReplaceAll(vendorAndName, ".", "_")
 
 	if repo.Pa.CodiceIPA == "" {
 		ID := repo.generateID()


### PR DESCRIPTION
The real problem was [here](https://github.com/italia/developers-italia-backend/blob/e8783570794edda42d6aabb8bbd246caa830e3ef/crawler/crawler/github.go#L274), whether querying api for one of repositories inside an organisation or user returns an error that return caused `exit` from repositories loop and skipping the evaluation of others repo in list.
Will fixes #112 