### PR TITLE
Gitlab on prem failed to get publiccode raw url

### DIFF
--- a/crawler/crawler/gitlab.go
+++ b/crawler/crawler/gitlab.go
@@ -299,7 +299,7 @@ func RegisterSingleGitlabAPI() SingleRepoHandler {
 		}
 
 		// Join file raw URL string.
-		_, err = generateGitlabRawURL(result.WebURL, result.DefaultBranch)
+		fileRawURL, err := generateGitlabRawURL(result.WebURL, result.DefaultBranch)
 		if err != nil {
 			return err
 		}
@@ -315,7 +315,7 @@ func RegisterSingleGitlabAPI() SingleRepoHandler {
 		if result.DefaultBranch != "" {
 			repositories <- Repository{
 				Name:        result.PathWithNamespace,
-				FileRawURL:  u.String(),
+				FileRawURL:  fileRawURL,
 				GitCloneURL: result.HTTPURLToRepo,
 				GitBranch:   result.DefaultBranch,
 				Hostname:    u.Hostname(),


### PR DESCRIPTION
Gitlab platform on premises failed to get raw url for `publiccode.yml`. 