### PR TITLE
Add Comune Open Web

### DIFF
--- a/crawler/whitelist/thirdparty.yml
+++ b/crawler/whitelist/thirdparty.yml
@@ -41,3 +41,7 @@
 - name: "WikiToLearn"
   repos:
     - "https://github.com/WikiToLearn/WikiToLearn"
+    
+ - name: "Comune Open Web"
+  repos:
+    - "https://github.com/klanit/comune-open-web"


### PR DESCRIPTION
Segnaliamo il nostro progetto per un sito web comunale aderente alle linee guida agid. Si chiama Comune Open Web