### PR TITLE
Logs more verbose #110

### DIFF
--- a/crawler/crawler/repo_activity.go
+++ b/crawler/crawler/repo_activity.go
@@ -64,6 +64,7 @@ func (repository *Repository) CalculateRepoActivity(days int) (float64, map[int]
 	r, err := git.PlainOpen(path)
 	if err != nil {
 		log.Error(err)
+		return 0, nil, err
 	}
 
 	// Extract all the commits.

--- a/crawler/crawler/saveToFile.go
+++ b/crawler/crawler/saveToFile.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/italia/developers-italia-backend/crawler/metrics"
 	log "github.com/sirupsen/logrus"
@@ -61,7 +62,8 @@ func logBadYamlToFile(fileRawURL string) {
 		log.Errorf(err.Error())
 	}
 
-	_, err = f.WriteString(fileRawURL + "\r\n")
+	_, err = f.WriteString(time.Now().Format("2006-01-02T15:04:05") + " - " + fileRawURL + "\r\n")
+
 	if err != nil {
 		log.Errorf(err.Error())
 	}


### PR DESCRIPTION
According to #110 this pr aims to have a more verbose logs on `bad_publiccodes.lst` file getting troubleshooting easier.
It also fixes a missing return.