### PR TITLE
Added project GovPay

### DIFF
--- a/crawler/whitelist/thirdparty.yml
+++ b/crawler/whitelist/thirdparty.yml
@@ -46,3 +46,7 @@
   repos:
     - "https://gitlab.com/opencontent/stanzadelcittadino"
     - "https://gitlab.com/opencontent/openagenda-translate"
+    
+- name: "Link.it"
+  repos:
+    - "https://github.com/link-it/govpay"


### PR DESCRIPTION
Added reference to GovPay's github repository, open source implementation of PAP (Porta Applicativa dei Pagamenti) introduced by pagoPA specifications.