### PR TITLE
IPA code were not matched correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ The crawler finds and retrieves all the publiccode.yml files from the Organizati
 6. start the Docker stack: `make up`
 
 #### Crawler
+Crawler will check if a match exists between IPA code in whitelists and in its related `publiccode.yml`. This validation process is skipped using `one` command since in that mode the repository given could not exists in crawler's whitelists.
+
+### Compile
 
 1. `cd crawler`
 2. Fill your domains.yml file with configuration values (like specific host basic auth tokens)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The crawler finds and retrieves all the publiccode.yml files from the Organizati
 6. start the Docker stack: `make up`
 
 #### Crawler
-Crawler will check if a match exists between IPA code in whitelists and in its related `publiccode.yml`. This validation process is skipped using `one` command since in that mode the repository given could not exists in crawler's whitelists.
+Crawler will check if a match exists between IPA code in whitelists and in its related `publiccode.yml`. This validation process is skipped using `one` command since in that mode the repository given could not exist in crawler's whitelists.
 
 ### Compile
 

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -335,12 +335,6 @@ func getRemoteFile(data []byte, fileRawURL string, pa PA) (publiccode.Parser, er
 // with relative entry in whitelist.
 // Using `one` command this check will be skipped.
 func validateFile(pa PA, parser publiccode.Parser, fileRawURL string) error {
-	log.Infof("paIPA %v with %d, pcIPA %v with %d",
-		strings.TrimSpace(pa.CodiceIPA),
-		len(strings.TrimSpace(pa.CodiceIPA)),
-		strings.TrimSpace(parser.PublicCode.It.Riuso.CodiceIPA),
-		len(strings.TrimSpace(parser.PublicCode.It.Riuso.CodiceIPA)))
-
 	if !strings.EqualFold(
 		strings.TrimSpace(pa.CodiceIPA),
 		strings.TrimSpace(parser.PublicCode.It.Riuso.CodiceIPA),

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -113,7 +113,7 @@ func (c *Crawler) CrawlRepo(repoURL string) error {
 		return err
 	}
 
-	// since this routine is called from one command
+	// since this routine is called by command: `<command_name> one ...`
 	// that is not aware about whitelists
 	// this hack will skip IPA code match with those lists
 	pa := &PA{

--- a/crawler/crawler/crawler_test.go
+++ b/crawler/crawler/crawler_test.go
@@ -1,0 +1,60 @@
+package crawler
+
+import (
+	"io/ioutil"
+	"testing"
+
+	publiccode "github.com/italia/publiccode-parser-go"
+	log "github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var whitelist string = `
+-
+  name: testit
+  repos: 
+    - "https://github.com/test/testrepo"
+-
+  codice-iPA:
+  name: testit
+  repos: 
+    - "https://github.com/test/testrepo"
+-
+  codice-iPA: test
+  name: testit
+  repos: 
+    - "https://github.com/test/testrepo"
+`
+
+// validateRemoteFile will parse and validate
+// crawled publiccode.yml. It will thrown errors
+// if parse fails and if IPA code mismatch between
+// whithelist file and publiccode itself
+func TestIPAMatch(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	var pas []PA
+	var parser publiccode.Parser
+	err := yaml.Unmarshal([]byte(whitelist), &pas)
+	if err != nil {
+		t.Errorf("error on unmarsalling whitelist %s", err)
+	}
+
+	// should not throw error codiceIPA key is equal
+	// on both sides
+	for _, pa := range pas {
+		parser.PublicCode.It.Riuso.CodiceIPA = pa.CodiceIPA
+		err = validateFile(pa, parser, "")
+		if err != nil {
+			t.Errorf("error comparing IPA codes %s", err)
+		}
+	}
+
+	// it should thowns errors since they always mismatch
+	for _, pa := range pas {
+		parser.PublicCode.It.Riuso.CodiceIPA = pa.CodiceIPA + "x"
+		err = validateFile(pa, parser, "")
+		if err == nil {
+			t.Errorf("error comparing IPA codes %v", err)
+		}
+	}
+}

--- a/crawler/crawler/whitelist.go
+++ b/crawler/crawler/whitelist.go
@@ -17,6 +17,7 @@ type PA struct {
 	CodiceIPA     string   `yaml:"codice-iPA"`
 	Organizations []string `yaml:"orgs"`
 	Repositories  []string `yaml:"repos"`
+	UnknownIPA    bool     `yaml:"unknown-iPA"`
 }
 
 // ReadAndParseWhitelist read the whitelist and return the parsed content in a slice of PA.


### PR DESCRIPTION
Crawler will check if a match exists between IPA code in whitelists and in its related `publiccode.yml`. This validation process is skipped using `one` command since in that mode the repository given could not exists in crawler's whitelists.