### PR TITLE
Delete command for crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The procedure described is the same automated in the Dockerfile. The -legacy and
 
 * `bin/crawler updateipa` downloads IPA data and writes them into Elasticsearch
 
+* `bin/crawler delete [URL]` delete software from Elasticsearch using its code hosting URL specified in `publiccode.url` 
+
 * `bin/crawler download-whitelist` downloads organizations and repositories from the [onboarding portal repository](https://github.com/italia/developers-italia-onboarding) and saves them to a whitelist file
 
 ### Docker: the legacy deployment process

--- a/crawler/cmd/delete.go
+++ b/crawler/cmd/delete.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/italia/developers-italia-backend/crawler/crawler"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete [repo url]",
+	Short: "Delete from ElasticSearch one single [repo url].",
+	Long: `Delete from ElasticSearch a single repository defined with [repo url].
+		No organizations! Only single repositories!`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		c := crawler.NewCrawler()
+
+		err := c.DeleteByQueryFromES(args[0])
+		if err != nil {
+			log.Error(err)
+		}
+
+		// Generate the data files for Jekyll.
+		err = c.ExportForJekyll()
+		if err != nil {
+			log.Errorf("Error while exporting data for Jekyll: %v", err)
+		}
+	},
+}

--- a/crawler/crawler/saveToElasticsearch.go
+++ b/crawler/crawler/saveToElasticsearch.go
@@ -149,6 +149,6 @@ func (c *Crawler) DeleteByQueryFromES(search string) error {
 		return errors.New("No records deleted for searched query")
 	}
 
-	log.Infof("Deleted %d record from ES", searchResult.Deleted)
+	log.Infof("Deleted %d record from ES linked to %s", searchResult.Deleted, search)
 	return nil
 }


### PR DESCRIPTION
As for #139 crawler is now able to delete item in Elasticsearch using `publiccode.url` as search parameter. It will also remove them from datafile used by Developers Italia's jekyll to build software catalog.
Administrations in data files and Elasticsearch are calculated from scratch due to its stateless implementation