### PR TITLE
one mode now will checks whitelist for IPA validation and slug generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The procedure described is the same automated in the Dockerfile. The -legacy and
 * Crawl mode (all item in whitelists): `bin/crawler crawl whitelist/*.yml`
 
 * One mode (single repository url): `bin/crawler one [repo url] whitelist/*.yml`
-  - In this mode will be evaluated one single repository at the time. IPA code will be matched with ones in whitelist, if organization is present, otherwise will be set to null and `slug` will have a random code in the end (instead of ipa code), furthermore, ipa code validation, a simple check within whitelists (which ensure that code belongs to selected PA), will be skipped.
+  - In this mode one single repository at the time will be evaluated. If the organization is present, its IPA code will be matched with the ones in whitelist otherwise it will be set to null and the `slug` will have a random code in the end (instead of the IPA code). Furthermore, the IPA code validation, which is a simple check within whitelists (to ensure that code belongs to the selected PA), will be skipped.
 
 * `bin/crawler updateipa` downloads IPA data and writes them into Elasticsearch
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ The procedure described is the same automated in the Dockerfile. The -legacy and
 
 * Build the crawler binary: `make`
 
-* Start the crawler: `bin/crawler crawl whitelist/*.yml`
-
 * Configure the crontab as desired
 
 ### Run the crawler
+* Crawl mode (all item in whitelists): `bin/crawler crawl whitelist/*.yml`
+
+* One mode (single repository url): `bin/crawler one [repo url] whitelist/*.yml`
+  - In this mode will be evaluated one single repository at the time. IPA code will be matched with ones in whitelist, if organization is present, otherwise will be set to null and `slug` will have a random code in the end (instead of ipa code), furthermore, ipa code validation, a simple check within whitelists (which ensure that code belongs to selected PA), will be skipped.
 
 * `bin/crawler updateipa` downloads IPA data and writes them into Elasticsearch
 

--- a/crawler/cmd/one.go
+++ b/crawler/cmd/one.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"regexp"
+
 	"github.com/italia/developers-italia-backend/crawler/crawler"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -11,14 +13,17 @@ func init() {
 }
 
 var oneCmd = &cobra.Command{
-	Use:   "one [repo url]",
+	Use:   "one [repo url] whitelist.yml whitelist/*.yml",
 	Short: "Crawl publiccode.yml from one single [repo url].",
-	Long: `Crawl publiccode.yml from a single repository defined with [repo url].
-No organizations! Only single repositories!`,
-	Args: cobra.ExactArgs(1),
+	Long: `Crawl publiccode.yml from a single repository defined with [repo url] 
+		according to the supplied whitelist file(s).
+		No organizations! Only single repositories!`,
+	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		c := crawler.NewCrawler()
-		err := c.CrawlRepo(args[0])
+
+		repoURL, whitelists := args[0], args[1:]
+		err := c.CrawlRepo(repoURL, getPAfromWhiteList(repoURL, whitelists))
 		if err != nil {
 			log.Error(err)
 		}
@@ -29,4 +34,42 @@ No organizations! Only single repositories!`,
 			log.Errorf("Error while exporting data for Jekyll: %v", err)
 		}
 	},
+}
+
+func getPAfromWhiteList(repoURL string, args []string) (pa crawler.PA) {
+	// Read the supplied whitelists.
+	var publishers []crawler.PA
+	for id := range args {
+		readWhitelist, err := crawler.ReadAndParseWhitelist(args[id])
+		if err != nil {
+			log.Fatal(err)
+		}
+		publishers = append(publishers, readWhitelist...)
+	}
+
+	for _, paWl := range publishers {
+		// looking into repositories
+		for _, paWlRepo := range paWl.Repositories {
+			log.Debugf("matching %s with %s", paWlRepo, repoURL)
+			if paWlRepo == repoURL {
+				log.Debugf("PA found in whitelist %+v", paWl)
+				return paWl
+			}
+		}
+		// looking into organizations
+		for _, paWlRepo := range paWl.Organizations {
+			log.Debugf("matching %s.* with %s", repoURL, paWlRepo)
+			if matched, _ := regexp.MatchString(paWlRepo+".*", repoURL); matched {
+				log.Debugf("PA found in whitelist %+v", paWl)
+				return paWl
+			}
+		}
+	}
+
+	log.Warn("PA not found in whitelist, slug will be generated without coideIPA")
+	// since this routine is called by command: `<command_name> one ...`
+	// that is not aware about whitelists
+	// this hack will skip IPA code match with those lists
+	pa.UnknownIPA = true
+	return pa
 }

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -104,7 +104,7 @@ func NewCrawler() *Crawler {
 }
 
 // CrawlRepo crawls a single repository.
-func (c *Crawler) CrawlRepo(repoURL string) error {
+func (c *Crawler) CrawlRepo(repoURL string, pa PA) error {
 	log.Infof("Processing repository: %s", repoURL)
 
 	// Check if current host is in known in domains.yml hosts.
@@ -113,15 +113,8 @@ func (c *Crawler) CrawlRepo(repoURL string) error {
 		return err
 	}
 
-	// since this routine is called by command: `<command_name> one ...`
-	// that is not aware about whitelists
-	// this hack will skip IPA code match with those lists
-	pa := &PA{
-		UnknownIPA: true,
-	}
-
 	// Process repository.
-	err = domain.processSingleRepo(repoURL, c.repositories, *pa)
+	err = domain.processSingleRepo(repoURL, c.repositories, pa)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this mode will be evaluated one single repository at the time. IPA code will be matched with ones in whitelist, if organization is present, otherwise will be set to null and `slug` will have a random code in the end (instead of ipa code), furthermore, ipa code validation, a simple check within whitelists (which ensure that code belongs to selected PA), will be skipped.