### PR TITLE
Counter for failed http did not increment

### DIFF
--- a/crawler/httpclient/httpclient.go
+++ b/crawler/httpclient/httpclient.go
@@ -102,6 +102,9 @@ func GetURL(URL string, headers map[string]string) (HTTPResponse, error) {
 		}
 
 		defer resp.Body.Close()
+		log.Errorf("Unknown http status code: %s - Resource: %s", resp.Status, URL)
+		// increment attempts
+		expBackoffAttempts++
 	}
 
 	// Generic invalid status code.


### PR DESCRIPTION
When doing http get and got a failed httpstatus, crawler will retry for [times](https://github.com/italia/developers-italia-backend/blob/master/crawler/httpclient/httpclient.go#L29) applying different rules based on error type.
Whether an unknown status is received that counter were not incremented and an infinite loop was triggered.