### PR TITLE
Related softwares now have codiceIPA

### DIFF
--- a/crawler/jekyll/softwares.go
+++ b/crawler/jekyll/softwares.go
@@ -33,6 +33,11 @@ type software struct {
 			Features      []string `json:"features"`
 			Screenshots   []string `json:"screenshots,omitempty"`
 		} `json:"description"`
+		It struct {
+			Riuso struct {
+				CodiceIPA string `json:"codiceIPA,omitempty"`
+			} `json:"riuso"`
+		} `json:"it"`
 		Categories []string `json:"categories"`
 		Legal      struct {
 			RepoOwner string `json:"repoOwner,omitempty"`


### PR DESCRIPTION
fixes #150 
Related softwares now have `codiceIPA` and they can be distinguished from third party.