### PR TITLE
[#172] Add activity days in config file

### DIFF
--- a/crawler/config.toml.example
+++ b/crawler/config.toml.example
@@ -34,3 +34,6 @@ OUTPUT_DIR = "/var/crawler/output"
 # Blacklist folder
 BLACKLIST_FOLDER = "blacklist/"
 BLACKLIST_PATTERN = "*.yml"
+
+# Number of days for activity (vitality index) calculation
+ACTIVITY_DAYS = 60

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -314,11 +314,10 @@ func (c *Crawler) ProcessRepo(repository Repository) {
 		log.Errorf("[%s] error while cloning: %v", repository.Name, err)
 	}
 
-	// Calculate Repository activity index and vitality.
+	// Calculate Repository activity index and vitality. Defaults to 60 days.
+	var activityDays int = 60
 	if viper.IsSet("ACTIVITY_DAYS") {
-		activityDays := viper.GetInt("ACTIVITY_DAYS")
-	} else {
-		activityDays := 60
+		activityDays = viper.GetInt("ACTIVITY_DAYS")
 	}
 	activityIndex, vitality, err := repository.CalculateRepoActivity(activityDays)
 	if err != nil {

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -315,7 +315,7 @@ func (c *Crawler) ProcessRepo(repository Repository) {
 	}
 
 	// Calculate Repository activity index and vitality.
-  activityDays := viper.GetInt("ACTIVITY_DAYS")
+	activityDays := viper.GetInt("ACTIVITY_DAYS")
 	activityIndex, vitality, err := repository.CalculateRepoActivity(activityDays)
 	if err != nil {
 		log.Errorf("[%s] error calculating activity index: %v", repository.Name, err)

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -315,7 +315,11 @@ func (c *Crawler) ProcessRepo(repository Repository) {
 	}
 
 	// Calculate Repository activity index and vitality.
-	activityDays := viper.GetInt("ACTIVITY_DAYS")
+	if viper.IsSet("ACTIVITY_DAYS") {
+		activityDays := viper.GetInt("ACTIVITY_DAYS")
+	} else {
+		activityDays := 60
+	}
 	activityIndex, vitality, err := repository.CalculateRepoActivity(activityDays)
 	if err != nil {
 		log.Errorf("[%s] error calculating activity index: %v", repository.Name, err)

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -315,11 +315,12 @@ func (c *Crawler) ProcessRepo(repository Repository) {
 	}
 
 	// Calculate Repository activity index and vitality.
-	activityIndex, vitality, err := repository.CalculateRepoActivity(60)
+  activityDays := viper.GetInt("ACTIVITY_DAYS")
+	activityIndex, vitality, err := repository.CalculateRepoActivity(activityDays)
 	if err != nil {
 		log.Errorf("[%s] error calculating activity index: %v", repository.Name, err)
 	}
-	log.Infof("[%s] activity index: %f", repository.Name, activityIndex)
+	log.Infof("[%s] activity index in the last %d days: %f", repository.Name, activityDays, activityIndex)
 	var vitalitySlice []int
 	for i := 0; i < len(vitality); i++ {
 		vitalitySlice = append(vitalitySlice, int(vitality[i]))


### PR DESCRIPTION
This PR:
* adds the `ACTIVITY_DAYS` const in the `config.toml` and reads it.

Fixes #172 

We should probably set a `viper.SetDefault("ACTIVITY_DAYS", "60")` in the initialization or default to `60` if that makes sense. 