### PR TITLE
Revert "chore: arpa-puglia repos blacklisted, no longer available"

### DIFF
--- a/crawler/blacklist/blacklist.yml
+++ b/crawler/blacklist/blacklist.yml
@@ -5,15 +5,3 @@
 ---
 
 repos:
-  - url: https://github.com/arpa-puglia/infoariaarpa
-    reason: 1
-    description: Repository currently not available
-  - url: https://github.com/arpa-puglia/infoaria
-    reason: 1
-    description: Repository currently not available
-  - url: https://github.com/arpa-puglia/accessoatti
-    reason: 1
-    description: Repository currently not available
-  - url: https://github.com/arpa-puglia/casarpa
-    reason: 1
-    description: Repository currently not available


### PR DESCRIPTION
We can't exclude missing repos by using blacklists because the
crawler won't see them in the first place and thus it won't
filter them out (and remove them from Elasticsearch) using the
blacklist.

This reverts commit 5e72b33e0c2b3809a8b184c70a15d7de359ce789.