### PR TITLE
chore(ci): use actions/checkout when building

### DIFF
--- a/.github/workflows/test_and_publish_docker_image.yml
+++ b/.github/workflows/test_and_publish_docker_image.yml
@@ -25,6 +25,7 @@ jobs:
 
     if: ${{ github.event_name != 'pull_request' }}
     steps:
+      - uses: actions/checkout@v2
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Explicitly use actions/checkout so the .git directory is present when
building. git's history is used to infer the crawler's version.