### PR TITLE
chore: re-enable cmdrc/gasplanet repository

### DIFF
--- a/crawler/blacklist/blacklist.yml
+++ b/crawler/blacklist/blacklist.yml
@@ -5,6 +5,3 @@
 ---
 
 repos:
-  - url: https://github.com/cmdrc/gasplanet
-    reason: 1
-    description: Repository empty


### PR DESCRIPTION
Re-enable formerly empty repository blacklisted in bbb61860616f9.