### PR TITLE
feat: add dry-run mode to "crawl" and "one" commands

### DIFF
--- a/crawler/cmd/crawl.go
+++ b/crawler/cmd/crawl.go
@@ -7,6 +7,8 @@ import (
 )
 
 func init() {
+	crawlCmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "perform a dry run with no changes made")
+
 	rootCmd.AddCommand(crawlCmd)
 }
 
@@ -17,7 +19,7 @@ var crawlCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		orgs := make(map[string]bool)
-		c := crawler.NewCrawler()
+		c := crawler.NewCrawler(dryRun)
 
 		// Read the supplied whitelists.
 		var publishers []crawler.PA

--- a/crawler/cmd/delete.go
+++ b/crawler/cmd/delete.go
@@ -17,7 +17,7 @@ var deleteCmd = &cobra.Command{
 		No organizations! Only single repositories!`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		c := crawler.NewCrawler()
+		c := crawler.NewCrawler(false)
 
 		err := c.DeleteByQueryFromES(args[0])
 		if err != nil {

--- a/crawler/cmd/export.go
+++ b/crawler/cmd/export.go
@@ -15,7 +15,7 @@ var exportCmd = &cobra.Command{
 	Short: "Export YAML files.",
 	Long:  `Export YAML files for the front end.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		c := crawler.NewCrawler()
+		c := crawler.NewCrawler(false)
 
 		// Generate the data files for Jekyll.
 		err := c.ExportForJekyll()

--- a/crawler/cmd/one.go
+++ b/crawler/cmd/one.go
@@ -9,6 +9,8 @@ import (
 )
 
 func init() {
+	oneCmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "perform a dry run with no changes made")
+
 	rootCmd.AddCommand(oneCmd)
 }
 
@@ -26,7 +28,7 @@ var oneCmd = &cobra.Command{
 			return
 		}
 
-		c := crawler.NewCrawler()
+		c := crawler.NewCrawler(dryRun)
 
 		repoURL, whitelists := args[0], args[1:]
 		err := c.CrawlRepo(repoURL, getPAfromWhiteList(repoURL, whitelists))

--- a/crawler/cmd/root.go
+++ b/crawler/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var dryRun bool
 var rootCmd = &cobra.Command{
 	Use:   "crawler",
 	Short: "A crawler for publiccode.yml files.",


### PR DESCRIPTION
Running crawl or one with --dry-run or -n, runs without:

- connectiong and performing changes to ElasticSearch
- cloning the repositories locally
- writing output files

Solves part of #79.