### PR TITLE
feat: add name field as keyword in Elasticsearch

### DIFF
--- a/crawler/elastic/elastic.go
+++ b/crawler/elastic/elastic.go
@@ -151,7 +151,8 @@ const (
         "name": {
           "type": "text",
           "analyzer": "autocomplete",
-          "search_analyzer": "autocomplete_search"
+          "search_analyzer": "autocomplete_search",
+          "fields": { "keyword": { "type": "keyword", "ignore_above": 256 } }
         },
         "applicationSuite": {
           "type": "text",


### PR DESCRIPTION
Map name.keyword to a keyword field so that we can sort by it.