### PR TITLE
chore: add new oas checker repo

### DIFF
--- a/crawler/whitelist/manual-reuse.yml
+++ b/crawler/whitelist/manual-reuse.yml
@@ -14,6 +14,7 @@
     - "https://github.com/italia/publiccode-editor"
     - "https://github.com/italia/design-comuni-pagine-statiche"
     - "https://github.com/italia/form-pa"
+    - "https://github.com/italia/api-oas-checker"
     - "https://github.com/immuni-app/immuni"
 
 - name: "Ministero per i Beni e le Attività Culturali"


### PR DESCRIPTION
This PR:

* adds the new `api-oas-checker` location under `/italia`
