### PR TITLE
Updated repository URL of stanzadelcittadino

### DIFF
--- a/crawler/whitelist/thirdparty.yml
+++ b/crawler/whitelist/thirdparty.yml
@@ -52,7 +52,7 @@
 
 - name: "Opencontent"
   repos:
-    - "https://gitlab.com/opencontent/stanzadelcittadino"
+    - "https://gitlab.com/opencontent/stanza-del-cittadino/core"
     - "https://gitlab.com/opencontent/opensegnalazioni"
     - "https://gitlab.com/opencontent/openagenda-translate"
     - "https://gitlab.com/opencontent/stanza-del-cittadino/pitre-soap-proxy"


### PR DESCRIPTION
Il software si sta arricchendo di svariati microservizi, quindi stiamo migrando tutti i repository sotto un unico gruppo.