### PR TITLE
feat: make publishers named "_" skip the same-repo check

### DIFF
--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -408,17 +408,22 @@ func (c *Crawler) ProcessRepo(repository Repository) {
 			return
 		}
 
-		err = validateFile(repository.Pa, *parser, repository.FileRawURL)
-		if err != nil {
-			message = fmt.Sprintf("[%s] BAD publiccode.yml: %+v\n", repository.Name, err)
-			log.Errorf(message)
-			addLogEntry(&logEntries, message)
+		// HACK: Publishers named "_"" are special and get to skip the additional checks.
+		// This can be used to add repositories and organizations, under the crawler's admins control,
+		// that describe arbitrary repos (eg. metarepos for other entities)
+		if repository.Pa.Name != "_" {
+			err = validateFile(repository.Pa, *parser, repository.FileRawURL)
+			if err != nil {
+				message = fmt.Sprintf("[%s] BAD publiccode.yml: %+v\n", repository.Name, err)
+				log.Errorf(message)
+				addLogEntry(&logEntries, message)
 
-			if ! c.DryRun {
-				logBadYamlToFile(repository.FileRawURL)
+				if ! c.DryRun {
+					logBadYamlToFile(repository.FileRawURL)
+				}
+
+				return
 			}
-
-			return
 		}
 	}
 

--- a/crawler/whitelist/thirdparty.yml
+++ b/crawler/whitelist/thirdparty.yml
@@ -5,6 +5,12 @@
 
 ---
 
+# Special organization that can describe software outside
+# of it.
+- name: "_"
+  orgs:
+    - "https://github.com/italia-software"
+
 - name: "GlobaLeaks"
   repos:
     - "https://github.com/globaleaks/GlobaLeaks"


### PR DESCRIPTION
Publishers named "_"" are special and get to skip the additional checks,
like the publiccode.yml's url needing to be on the same repo.

They can be used to add repositories and organizations, under the
crawler's admins control, that describe arbitrary repos
(eg. metarepos for other entities)

This is an hack while we come up with a more elegant solution, after
the crawler's refactor.
