### PR TITLE
fix: use publiccode.yml's url when cloning the repo locally

### DIFF
--- a/crawler/crawler/cloneRepository.go
+++ b/crawler/crawler/cloneRepository.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CloneRepository clone the repository into DATADIR/repos/<hostname>/<vendor>/<repo>/gitClone
-func CloneRepository(domain Domain, hostname, name, gitURL, gitBranch, index string) error {
+func CloneRepository(domain Domain, hostname, name, gitURL, index string) error {
 	if domain.Host == "" {
 		return errors.New("cannot save a file without domain host")
 	}
@@ -33,17 +33,13 @@ func CloneRepository(domain Domain, hostname, name, gitURL, gitBranch, index str
 		if err != nil {
 			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
 		}
-		// Command is: git reset --hard origin/<branch_name>
-		out, err = exec.Command("git", "-C", path, "reset", "--hard", "origin/"+gitBranch).CombinedOutput() // nolint: gas
-		if err != nil {
-			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
-		}
-		return err
+
+		return nil
 	}
 
 	// Clone the repository using the external command "git".
 	// Command is: git clone -b <branch> <remote_repo>
-	out, err := exec.Command("git", "clone", "-b", gitBranch, gitURL, path).CombinedOutput() // nolint: gas
+	out, err := exec.Command("git", "clone", gitURL, path).CombinedOutput() // nolint: gas
 	if err != nil {
 		return errors.New(fmt.Sprintf("cannot git clone the repository: %s: %s", err.Error(), out))
 	}

--- a/crawler/crawler/cloneRepository.go
+++ b/crawler/crawler/cloneRepository.go
@@ -33,6 +33,10 @@ func CloneRepository(domain Domain, hostname, name, gitURL, index string) error 
 		if err != nil {
 			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
 		}
+		out, err = exec.Command("git", "-C", path, "reset", "--hard", "origin/HEAD").CombinedOutput() // nolint: gas
+		if err != nil {
+			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
+		}
 
 		return nil
 	}

--- a/crawler/crawler/crawler.go
+++ b/crawler/crawler/crawler.go
@@ -437,7 +437,7 @@ func (c *Crawler) ProcessRepo(repository Repository) {
 	}
 
 	// Clone repository.
-	err = CloneRepository(repository.Domain, repository.Hostname, repository.Name, repository.GitCloneURL, repository.GitBranch, c.index)
+	err = CloneRepository(repository.Domain, repository.Hostname, repository.Name, parser.PublicCode.URL.String(), c.index)
 	if err != nil {
 		message = fmt.Sprintf("[%s] error while cloning: %v\n", repository.Name, err)
 		log.Errorf(message)


### PR DESCRIPTION
Use the URL in publiccode.yml when cloning the repo locally, so the
vitality of software using metarepos is calculated against the actual software
repository instead of the metarepo itself.

Fix #264.