### PR TITLE
feat: clone bare repositories without blobs

### DIFF
--- a/crawler/crawler/cloneRepository.go
+++ b/crawler/crawler/cloneRepository.go
@@ -33,17 +33,12 @@ func CloneRepository(domain Domain, hostname, name, gitURL, index string) error 
 		if err != nil {
 			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
 		}
-		out, err = exec.Command("git", "-C", path, "reset", "--hard", "origin/HEAD").CombinedOutput() // nolint: gas
-		if err != nil {
-			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
-		}
-
 		return nil
 	}
 
 	// Clone the repository using the external command "git".
-	// Command is: git clone -b <branch> <remote_repo>
-	out, err := exec.Command("git", "clone", gitURL, path).CombinedOutput() // nolint: gas
+	// Command is: git clone --filter=blob:none --mirror -b <branch> <remote_repo>
+	out, err := exec.Command("git", "clone", "--filter=blob:none", "--mirror", "-b", gitURL, path).CombinedOutput() // nolint: gas
 	if err != nil {
 		return errors.New(fmt.Sprintf("cannot git clone the repository: %s: %s", err.Error(), out))
 	}

--- a/crawler/crawler/cloneRepository.go
+++ b/crawler/crawler/cloneRepository.go
@@ -28,7 +28,6 @@ func CloneRepository(domain Domain, hostname, name, gitURL, index string) error 
 
 	// If folder already exists it will do a fetch instead of a clone.
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		//	Command is: git fetch --all
 		out, err := exec.Command("git", "-C", path, "fetch", "--all").CombinedOutput() // nolint: gas
 		if err != nil {
 			return errors.New(fmt.Sprintf("cannot git pull the repository: %s: %s", err.Error(), out))
@@ -36,8 +35,6 @@ func CloneRepository(domain Domain, hostname, name, gitURL, index string) error 
 		return nil
 	}
 
-	// Clone the repository using the external command "git".
-	// Command is: git clone --filter=blob:none --mirror -b <branch> <remote_repo>
 	out, err := exec.Command("git", "clone", "--filter=blob:none", "--mirror", "-b", gitURL, path).CombinedOutput() // nolint: gas
 	if err != nil {
 		return errors.New(fmt.Sprintf("cannot git clone the repository: %s: %s", err.Error(), out))


### PR DESCRIPTION
In order to save disk space, make bare clones of repositories filtering out blobs.

Fixes #249 