### PR TITLE
chore: don't login to DockerHub on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,6 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Docker Login
-        if: success() && startsWith(github.ref, 'refs/tags/v')
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Goreleaser is not in charge of the Docker image build: that's done
in a different workflow (test_and_publish_docker_image.yml).