### PR TITLE
added Spunta to third party list

### DIFF
--- a/publishers.thirdparty.yml
+++ b/publishers.thirdparty.yml
@@ -142,3 +142,7 @@
 - name: "Trasporti Lecce"
   repos:
     - "https://github.com/piersoft/trasportilecceeu"
+
+- name: "Spunta"
+  repos:
+    - "https://gitlab.com/madbob/spunta"


### PR DESCRIPTION
Spunta is a simple checklist manager, already adopted by a few Red Cross local groups for routine revision of equipments. Probably this is interesting also to other kind of subjects, even within public administration.